### PR TITLE
refactor: adjust notables as seen in fextralifes leaked review

### DIFF
--- a/src/lib/data/nodes_desc.json
+++ b/src/lib/data/nodes_desc.json
@@ -6949,8 +6949,8 @@
     "stats": []
   },
   "S1059": {
-    "name": "S1059",
-    "stats": []
+    "name": "Projectile Damage",
+    "stats": ["10% increased Projectile Damage"]
   },
   "S1060": {
     "name": "S1060",
@@ -7057,8 +7057,8 @@
     "stats": []
   },
   "S1086": {
-    "name": "S1086",
-    "stats": []
+    "name": "Projectile Damage",
+    "stats": ["10% increased Projectile Damage"]
   },
   "S1087": {
     "name": "S1087",

--- a/src/lib/data/nodes_desc.json
+++ b/src/lib/data/nodes_desc.json
@@ -1516,8 +1516,8 @@
 		"stats": ["10% increased Stun Buildup", "10% increased Melee Damage", "+10 to Strength"]
 	},
 	"N313": {
-		"name": "Master Fletcher",
-		"stats": ["8% increased Projectile Speed","8% increased Attack Speed with Bows","8% increased Attack Speed with Crossbows"]
+		"name": "Clean Shot",
+		"stats": ["15% chance to Pierce an Enemy","15% increased Projectile Damage"]
 	},
 	"N314": {
 		"name": "Shattering Blow",
@@ -1600,8 +1600,8 @@
 		"stats": []
 	},
 	"N334": {
-		"name": "Hold Focus",
-		"stats": ["12% increased Effect of your Marks"]
+		"name": "Mark Cast Speed",
+		"stats": ["Mark Skills have 10% increased Cast Speed"]
 	},
 	"N335": {
 		"name": "N335",
@@ -1625,7 +1625,7 @@
 	},
 	"N340": {
 		"name": "Break Focus",
-		"stats": ["12% increased Effect of your Marks"]
+		"stats": ["Enemies you Mark have 15% reduced Accuracy Rating"]
 	},
 	"N341": {
 		"name": "N341",
@@ -1807,8 +1807,8 @@
 		"stats": []
 	},
 	"N380": {
-		"name": "Flask Charges Gained Notable",
-		"stats": ["25% increased Flask Charges gained"]
+		"name": "Lasting Concoctions",
+		"stats": ["25% increased Flask Effect Duration", "25% increased Flask Charges gained"]
 	},
 	"N381": {
 		"name": "N381",


### PR DESCRIPTION
Fextralife released a 15 minute review of PoE2 early (https://www.youtube.com/watch?v=yJw7zF9EE90). Since then he privated that video.

I assume that video was the most up to date version of PoE2, more up to date than the other videos we based our perk tree knowledge off of.
Any notable I saw in his footage I treat as being more correct.


**Clean Shot** (previously **Master Fletcher**)
https://www.twitch.tv/videos/2314593043?t=7h55m20s
![image](https://github.com/user-attachments/assets/5c9bb4f7-b249-408f-a245-ab896069e10d)

**Honed Instincts**
https://www.twitch.tv/videos/2314593043?t=7h55m48s
![image](https://github.com/user-attachments/assets/2fedc9f0-8f14-4770-9022-7a2912bd66b1)

**Lasting Concoctions** (previously unnamed)
https://www.twitch.tv/videos/2314593043?t=7h55m50s
![image](https://github.com/user-attachments/assets/f7e9e33b-e0a1-4c78-8546-3f6f86b164f5)

**Break Focus**
https://www.twitch.tv/videos/2314593043?t=7h55m51s
![image](https://github.com/user-attachments/assets/db4833e6-72a7-4850-b850-7b250879e226)

**Mark Cast Speed** (previously **Hold Focus**)
https://www.twitch.tv/videos/2314593043?t=7h55m51s (only visible for close to 1 frame)
![image](https://github.com/user-attachments/assets/756cab13-3677-4714-b163-476367f3f2c5)