### PR TITLE
refactor: shift complexity from template to logical locations

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,30 +1,60 @@
 // place files you want to import through the `$lib` alias in this folder.
-import nodes from '$lib/data/nodes.json';
-import nodesDesc from '$lib/data/nodes_desc.json';
+import nodePositions from '$lib/data/nodes.json';
+import nodeData from '$lib/data/nodes_desc.json';
+
+interface NodeDataJSON {
+	[nodeID: string]: {
+		name: string;
+		stats: string[];
+	};
+}
 
 export interface NodePosition {
 	x: number;
 	y: number;
+}
+
+export interface TreeNode {
 	id: string;
-}
-
-interface NodePositionStructure {
-	keystones: NodePosition[];
-	notables: NodePosition[];
-	smalls: NodePosition[];
-}
-
-export interface TooltipContent {
+	type: 'keystone' | 'notable' | 'small';
+	position: NodePosition;
 	name: string;
-	stats: string[];
+	description: string[];
 }
 
-export function loadData(): {
-	positions: NodePositionStructure;
-	nodesDescription: { [key: string]: TooltipContent };
-} {
-	return {
-		positions: nodes,
-		nodesDescription: nodesDesc
-	};
+export interface NodeMap {
+	[nodeID: string]: TreeNode;
+}
+
+export interface TreeData {
+	nodes: NodeMap;
+}
+
+// massage our 2 data sources into a single map of nodes to simplify our usage.
+export function loadData(): TreeData {
+	const flattenedNodePositions = [
+		...nodePositions.keystones,
+		...nodePositions.notables,
+		...nodePositions.smalls
+	];
+
+	const nodes = flattenedNodePositions.reduce((acc, node) => {
+		const { name, stats: description } = (nodeData as NodeDataJSON)[node.id];
+
+		return {
+			...acc,
+			[node.id]: {
+				id: node.id,
+				name,
+				description,
+				type: node.kind,
+				position: {
+					x: node.x,
+					y: node.y
+				}
+			}
+		};
+	}, {}) as NodeMap;
+
+	return { nodes };
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { base } from '$app/paths';
-	import { type NodePosition, type TooltipContent, loadData } from '$lib';
+	import { type TreeNode, loadData } from '$lib';
 	import { onMount, tick } from 'svelte';
 	import { browser } from '$app/environment';
 
-	let { positions: nodes, nodesDescription: nodesDesc } = loadData();
+	let { nodes } = loadData();
 
 	let containerEl: HTMLDivElement | null = null;
 	let imageEl: HTMLImageElement | null = null;
@@ -12,7 +12,7 @@
 	let tooltipEl: HTMLDivElement | null = null; // Reference to the tooltip element
 	let hasLoaded = false;
 
-	let tooltipContent: TooltipContent | null = null;
+	let tooltipNode: TreeNode | null = null;
 	let tooltipX = 0;
 	let tooltipY = 0;
 
@@ -41,6 +41,7 @@
 	// Load saved selected nodes from localStorage on component initialization
 	if (browser) {
 		const savedSelectedNodes = localStorage.getItem('selectedSkillNodes');
+
 		if (savedSelectedNodes) {
 			try {
 				selectedNodes = JSON.parse(savedSelectedNodes);
@@ -80,14 +81,45 @@
 	// Reactive statement for search
 	$: handleSearch(searchTerm);
 
-	async function activateTooltip(node: NodePosition) {
-		tooltipContent = nodesDesc[node.id];
+	// composable filter functions
+	function filterSmallNodes(node: TreeNode) {
+		return !hideSmall || node.type !== 'small';
+	}
+
+	function filterUnselectedNodes(node: TreeNode) {
+		return !hideUnselected || !selectedNodes.includes(node.id);
+	}
+
+	function filterUnidentifiedNodes(node: TreeNode) {
+		return !hideUnidentified || node.description.length > 0;
+	}
+
+	const filterFns = [filterSmallNodes, filterUnselectedNodes, filterUnidentifiedNodes];
+
+	// filter nodes using active filters
+	function filterNodes(node: TreeNode) {
+		return filterFns.every((filterFn) => filterFn(node));
+	}
+
+	const NODE_SIZE = {
+		notable: 20,
+		small: 10,
+		keystone: 24
+	};
+
+	// calculate node size in pixels based on type
+	function getNodeSize(node: TreeNode) {
+		return NODE_SIZE[node.type];
+	}
+
+	async function activateTooltip(node: TreeNode) {
+		tooltipNode = node;
 
 		if (!imageEl || !containerEl) return;
 
 		// Calculate node position relative to the container, accounting for pan offsets
-		const nodeX = node.x * imageEl.naturalWidth * scale + panOffsetX;
-		const nodeY = node.y * imageEl.naturalHeight * scale + panOffsetY;
+		const nodeX = node.position.x * imageEl.naturalWidth * scale + panOffsetX;
+		const nodeY = node.position.y * imageEl.naturalHeight * scale + panOffsetY;
 
 		// Initial tooltip position
 		tooltipX = nodeX + 20; // Adjust as needed
@@ -138,7 +170,7 @@
 		}
 	}
 
-	function toggleNodeSelection(node: NodePosition) {
+	function toggleNodeSelection(node: TreeNode) {
 		if (selectedNodes.includes(node.id)) {
 			// Deselect node
 			selectedNodes = selectedNodes.filter((id) => id !== node.id);
@@ -162,7 +194,7 @@
 		}
 	}
 
-	function handleMouseEnter(node: NodePosition) {
+	function handleMouseEnter(node: TreeNode) {
 		if (!isPanning) {
 			activateTooltip(node);
 		}
@@ -170,7 +202,7 @@
 
 	function handleMouseLeave() {
 		if (!isPanning) {
-			tooltipContent = null;
+			tooltipNode = null;
 		}
 	}
 
@@ -223,11 +255,11 @@
 
 		const search = text.toLowerCase();
 
-		searchResults = Object.entries(nodesDesc)
+		searchResults = Object.entries(nodes)
 			.filter(
 				([_, values]) =>
 					values.name.toLowerCase().includes(search) ||
-					values.stats.some((value) => value.toLowerCase().includes(search))
+					values.description.some((value) => value.toLowerCase().includes(search))
 			)
 			.map(([key, _]) => key);
 	}
@@ -258,6 +290,7 @@
 
 	function clearSelectedNodes() {
 		selectedNodes = [];
+
 		// Clear localStorage when all nodes are cleared
 		if (browser) {
 			localStorage.removeItem('selectedSkillNodes');
@@ -415,10 +448,10 @@
 				<ul>
 					{#each searchResults as nodeId}
 						<li>
-							<strong>{nodesDesc[nodeId].name}</strong>
+							<strong>{nodes[nodeId].name}</strong>
 							<ul>
-								{#each nodesDesc[nodeId].stats as stat}
-									<li>{stat}</li>
+								{#each nodes[nodeId].description as description}
+									<li>{description}</li>
 								{/each}
 							</ul>
 						</li>
@@ -448,10 +481,10 @@
 					{#each selectedNodes as nodeId}
 						{#if !nodeId.startsWith('S')}
 							<li>
-								<strong>{nodesDesc[nodeId].name}</strong>
+								<strong>{nodes[nodeId].name}</strong>
 								<ul>
-									{#each nodesDesc[nodeId].stats as stat}
-										<li>{stat}</li>
+									{#each nodes[nodeId].description as description}
+										<li>{description}</li>
 									{/each}
 								</ul>
 							</li>
@@ -502,58 +535,47 @@
 
 		<!-- Display hoverable regions with lighter color -->
 		{#if hasLoaded}
-			{#each ['notables', 'keystones', 'smalls'] as kind}
-				{#each nodes[kind] as node}
-					{#if !(hideSmall && node.id.startsWith('S'))}
-						{#if !(hideUnselected && !selectedNodes.includes(node.id))}
-							{#if !(hideUnidentified && nodesDesc[node.id].name === node.id)}
-								<!-- svelte-ignore a11y_no_static_element_interactions -->
-								<!-- svelte-ignore a11y_click_events_have_key_events -->
-								<div
-									class:notable={node.id.startsWith('N')}
-									class:keystone={node.id.startsWith('K')}
-									class:small={node.id.startsWith('S')}
-									class:unidentified={nodesDesc[node.id].name === node.id}
-									class:search-result={searchResults.includes(node.id)}
-									class:selected={selectedNodes.includes(node.id)}
-									class:highlighted-keystone={highlightKeystones && node.id.startsWith('K')}
-									class:highlighted-notable={highlightNotables && node.id.startsWith('N')}
-									class:highlighted-small={highlightSmalls && node.id.startsWith('S')}
-									style="
-								  width: {(baseNodeSize + node.id.startsWith('K') * 4 - node.id.startsWith('S') * 10) * scale}px;
-								  height: {(baseNodeSize + node.id.startsWith('K') * 4 - node.id.startsWith('S') * 10) * scale}px;
-								  left: {node.x * imageEl.naturalWidth * scale -
-										((baseNodeSize + node.id.startsWith('K') * 4 - node.id.startsWith('S') * 10) *
-											scale) /
-											2}px;
-								  top: {node.y * imageEl.naturalHeight * scale -
-										((baseNodeSize + node.id.startsWith('K') * 4 - node.id.startsWith('S') * 10) *
-											scale) /
-											2}px;
-							  "
-									onmousedown={(event) => event.stopPropagation()}
-									onclick={() => toggleNodeSelection(node)}
-									onmouseenter={() => handleMouseEnter(node)}
-									onmouseleave={handleMouseLeave}
-								></div>
-							{/if}
-						{/if}
-					{/if}
-				{/each}
+			{#each Object.values(nodes).filter(filterNodes) as node}
+				<!-- svelte-ignore a11y_no_static_element_interactions -->
+				<!-- svelte-ignore a11y_click_events_have_key_events -->
+				<div
+					class:keystone={node.type === 'keystone'}
+					class:notable={node.type === 'notable'}
+					class:small={node.type === 'small'}
+					class:unidentified={node.description.length === 0}
+					class:search-result={searchResults.includes(node.id)}
+					class:selected={selectedNodes.includes(node.id)}
+					class:highlighted-keystone={highlightKeystones && node.type === 'keystone'}
+					class:highlighted-notable={highlightNotables && node.type === 'notable'}
+					class:highlighted-small={highlightSmalls && node.type === 'small'}
+					style="
+						height: {getNodeSize(node) * scale}px;
+						width: {getNodeSize(node) * scale}px;
+						left: {node.position.x * imageEl.naturalWidth * scale - (getNodeSize(node) * scale) / 2}px;
+						top: {node.position.y * imageEl.naturalHeight * scale - (getNodeSize(node) * scale) / 2}px;
+					"
+					onmousedown={(event) => event.stopPropagation()}
+					onclick={() => toggleNodeSelection(node)}
+					onmouseenter={() => handleMouseEnter(node)}
+					onmouseleave={handleMouseLeave}
+				></div>
 			{/each}
 		{/if}
 	</div>
 
 	<!-- Tooltip displayed when a region is hovered -->
-	{#if tooltipContent != null}
+	{#if tooltipNode != null}
 		<div bind:this={tooltipEl} class="tooltip" style="left: {tooltipX}px; top: {tooltipY}px;">
 			<div class="title" style={`background-image: url('${base}/tooltip-header.png');`}>
-				{tooltipContent.name}
+				{tooltipNode.name}
 			</div>
 			<div class="body">
-				{#each tooltipContent.stats as stat}
-					<p class="stat-line">{stat}</p>
+				{#each tooltipNode.description as description}
+					<p class="description-line">{description}</p>
 				{/each}
+			</div>
+			<div class="footer">
+				<span class="node-id">{tooltipNode.id}</span>
 			</div>
 		</div>
 	{/if}
@@ -745,7 +767,7 @@
 			font-size: 1.5rem;
 			color: #f0e7e5; /* Light gold for the title text */
 			text-align: center;
-			margin-bottom: 15px;
+			margin-bottom: 8px;
 			background-size: cover; /* Ensure the image covers the entire title area */
 			background-position: center; /* Center the background image */
 			border-radius: 8px; /* Rounded corners */
@@ -761,11 +783,26 @@
 			font-size: 16px;
 			line-height: 1.5; /* Improve readability */
 			color: #7d7aad; /* Light blue for body text */
-			margin-bottom: 15px; /* Spacing below body */
-			padding: 10px 20px;
+			margin-bottom: 8px; /* Spacing below body */
+			padding: 8px 20px 0;
 
-			.stat-line {
+			.description-line {
 				margin: 0 auto;
+			}
+		}
+
+		.footer {
+			display: flex;
+			font-family: 'Fontin SmallCaps', sans-serif;
+			color: #7d7aad;
+			margin-bottom: 8px;
+			margin-left: 8px;
+			margin-right: 8px;
+
+			.node-id {
+				color: #888;
+				font-size: 12px;
+				margin-left: auto;
 			}
 		}
 	}


### PR DESCRIPTION
noticed things were getting messy in a few places as features were being added (nested conditionals in the template to support filtering, looking data up across 2 data sources, etc) so i refactored a bunch of complexity out. key things:

- massaging both data sources into a single `NodeMap` that contains `TreeNode`s which encapsulate all of the data in one place. could refactor the data sources but i think it works fine as is and it's much easier not to with active contributers. 
- updated all references to use the new simplified/combined structure and removed needless `each` loops in the template
- replaced nested `if` statements in the template with an `Array#filter -> Array#every` pattern that allows for simple filter function composition
- pulled repeated math out of the template for node size/position into a reusable function
- unrelated but adds value for contributing: added node IDs to the tooltips in small text in the bottom right corner (#80)

tested locally and seems fine. lmk if you have any feedback.