### PR TITLE
feat: add small nodes

### DIFF
--- a/src/lib/data/nodes_desc.json
+++ b/src/lib/data/nodes_desc.json
@@ -5436,8 +5436,8 @@
 		"stats": ["+5 to any Attribute"]
 	},
 	"S673": {
-		"name": "S673",
-		"stats": []
+		"name": "Mana Regeneration",
+		"stats": ["10% increased Mana Regeneration Rate"]
 	},
 	"S674": {
 		"name": "Mana",
@@ -5468,8 +5468,8 @@
 		"stats": []
 	},
 	"S681": {
-		"name": "S681",
-		"stats": []
+		"name": "Spell Damage",
+		"stats": ["8% increased Spell Damage"]
 	},
 	"S682": {
 		"name": "Attribute",

--- a/src/lib/data/nodes_desc.json
+++ b/src/lib/data/nodes_desc.json
@@ -5488,8 +5488,8 @@
 		"stats": ["+5 to any Attribute"]
 	},
 	"S686": {
-		"name": "Minion Life",
-		"stats": ["Minions have 10% increased maximum Life"]
+		"name": "Mana Regeneration",
+		"stats": ["10% increased Mana Regeneration Rate"]
 	},
 	"S687": {
 		"name": "S687",
@@ -5512,8 +5512,8 @@
 		"stats": ["+5 to any Attribute"]
 	},
 	"S692": {
-		"name": "S692",
-		"stats": []
+		"name": "Spell Damage",
+		"stats": ["8% increased Spell Damage"]
 	},
 	"S693": {
 		"name": "Energy Shield Delay",
@@ -5580,8 +5580,8 @@
 		"stats": ["3% increased Attack speed"]
 	},
 	"S709": {
-		"name": "S709",
-		"stats": []
+		"name": "Spell Damage",
+		"stats": ["10% increased Spell Damage"]
 	},
 	"S710": {
 		"name": "Energy Shield",


### PR DESCRIPTION
**Spell Damage** (new)
https://youtu.be/l_OXzSCHVzI?si=AmX8sngtgdZjUVpt&t=340
![image](https://github.com/user-attachments/assets/2fa98478-5476-4b4f-8750-2e661a1f585d)

**Mana Regeneration** (update)
https://youtu.be/l_OXzSCHVzI?si=J78zECLtZQ9avdYj&t=341
![image](https://github.com/user-attachments/assets/9621adb6-717e-4a96-89a0-7c6350e5a7f4)

**Spell Damage** (new)
https://youtu.be/l_OXzSCHVzI?si=hGdHJ7jt3blxno6x&t=342
![image](https://github.com/user-attachments/assets/b85ed8e5-bd76-492f-a1a5-f0d4a744aaca)

The second commit has two speculative small nodes, which are just the second respective node above the two nodes shown above.
It is common PoE1 skill tree design that such 2-point path have generally the same node effects.

Close: #90 