### PR TITLE
Feature: Pan to Node on Search Results

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -427,6 +427,39 @@
 			clearSearchTerm();
 		}
 	}
+
+	/**
+	 * Pans the view to center on the specified node.
+	 *
+	 * param {string} nodeId - The ID of the node to pan to.
+	 *
+	 * This function calculates the target position to center the view on the node
+	 * with the given `nodeId`. It adjusts the `panOffsetX` and `panOffsetY` values
+	 * based on the node's position and the current scale of the image. After calculating
+	 * the target position, it clamps the pan offsets to ensure the view remains within
+	 * the bounds of the container.
+	 *
+	 * Preconditions:
+	 * - `imageEl` and `containerEl` must be defined and reference valid DOM elements.
+	 * - `nodes` must contain the node with the specified `nodeId`.
+	 *
+	 * Postconditions:
+	 * - The view is panned to center on the specified node.
+	 * - The pan offsets are clamped to ensure the view remains within bounds.
+	 */
+	function panToNode(nodeId: string) {
+		if (!imageEl || !containerEl) return;
+		const rawNodePosition = nodes[nodeId].position;
+
+		const targetPosition = {
+			x: containerEl.clientWidth / 2 - rawNodePosition.x * imageEl.naturalWidth * scale,
+			y: containerEl.clientHeight / 2 - rawNodePosition.y * imageEl.naturalHeight * scale
+		};
+
+		panOffsetX = targetPosition.x;
+		panOffsetY = targetPosition.y;
+		clampPanOffsets();
+	}
 </script>
 
 <!-- page layout -->
@@ -544,7 +577,7 @@
 					<ul class="block min-h-0 overflow-y-auto">
 						{#each searchResults as nodeId}
 							<li>
-								<strong>{nodes[nodeId].name}</strong>
+								<button onclick={() => panToNode(nodeId)}>{nodes[nodeId].name}</button>
 								<ul>
 									{#each nodes[nodeId].description as description}
 										<li class="text-sm text-[#7d7aad]">{description}</li>


### PR DESCRIPTION
This feature adds the ability to pan the view to center on a specific node when a button is clicked in the search results. It introduces a new function, panToNode, which calculates the target position based on the node's coordinates and the current scale, then updates the pan offsets accordingly. This enhances the user experience by allowing quick navigation to nodes directly from the search results.