### PR TITLE
fixed spelling for Crushing Impacts stats

### DIFF
--- a/src/lib/data/nodes_desc.json
+++ b/src/lib/data/nodes_desc.json
@@ -10798,7 +10798,7 @@
 	},
 	"AN65": {
 		"name": "Crushing Impacts",
-		"stats": ["Yout Hits are Crushing Blows"]
+		"stats": ["Your Hits are Crushing Blows"]
 	},
 	"AN66": {
 		"name": "Surprising strength",


### PR DESCRIPTION
A very small contribution to fix the spelling of the stats property for Titan's Crushing Impact. Was previously "yout", how it's correctly "your".