### PR TITLE
feat: Update demon form stats

### DIFF
--- a/src/lib/data/nodes_desc.json
+++ b/src/lib/data/nodes_desc.json
@@ -10672,7 +10672,13 @@
 	},
 	"AN12": {
 		"name": "Demonic Possession",
-		"stats": ["Grants Skill: Demon Form"],
+		"stats": [
+			"Grants Skill: Demon Form",
+			"16% increased Cast Speed while in Demon Form",
+			"+4 to Level of all Spell Skills while in Demon Form",
+			"Lose 1% of Life per second per Demonflame",
+			"Deal 10% increased Spell damage per Demonflame"
+		],
 		"info": [
 			"title: Demon Form",
 			"Shapeshift into a demon, vastly boosting the power of your Spells. You gain Demonflame every second you remain in demon form, causing your Life to be lost at an ever-increasing rate. Revert to human form if you reach 1 Life, use a Skill that isn't a Spell, or reactivate this Skill."


### PR DESCRIPTION
I saw this issue and thought I could add the stats about `Demon Form`.

https://github.com/marcoaaguiar/poe2-tree/issues/145

![image](https://github.com/user-attachments/assets/e294b3d7-a80b-46e5-bad0-fc39c7a01356)

Let me know if you think this is a good improvement?